### PR TITLE
fix version requirement to use correct syntax

### DIFF
--- a/lib/Class/Meta/Express.pm
+++ b/lib/Class/Meta/Express.pm
@@ -2,7 +2,7 @@ package Class::Meta::Express;
 
 use strict;
 use vars qw($VERSION);
-use Class::Meta '0.60';
+use Class::Meta 0.60;
 
 $VERSION = '0.14';
 


### PR DESCRIPTION
Version numbers on a use line need to be unquoted to be handled properly. When they are quoted, they are passed in import instead. Part versions of perl ignored these arguments, but future versions are intending to throw errors for arguments given to an undefined import method.